### PR TITLE
Fix api limiter

### DIFF
--- a/config/wom.js
+++ b/config/wom.js
@@ -1,7 +1,7 @@
 const { WOMClient } = require('@wise-old-man/utils');
 const { Environment } = require('../services/environment');
 
-const WOM_RATE_LIMIT = 2;
+const WOM_RATE_LIMIT = Environment.WOM_API_KEY ? 100 : 20;
 const TIME_PER_TOKEN = 60000 / WOM_RATE_LIMIT;
 
 let womClient;

--- a/config/wom.js
+++ b/config/wom.js
@@ -12,8 +12,6 @@ const replenishTokens = () => {
     const now = Date.now();
     const elapsedTime = now - lastTokenReplenish;
     const tokensToAdd = Math.floor(elapsedTime / TIME_PER_TOKEN);
-    console.log('elapsed time', elapsedTime);
-    console.log('tokenstoAdd', tokensToAdd);
     availTokens = Math.min(availTokens + tokensToAdd, WOM_RATE_LIMIT);
     lastTokenReplenish = lastTokenReplenish + tokensToAdd * TIME_PER_TOKEN;
 };


### PR DESCRIPTION
Fixed the following:
- replenishTokens() was updating lastTokenReplenish even when no tokens were replenished
- WOMClient is an object of clients so its Proxy was returning another client instead of a proxy of that client with the same ratelimiter